### PR TITLE
Fix styling and ignore DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+server/university.db

--- a/src/App.css
+++ b/src/App.css
@@ -22,3 +22,9 @@ body {
   padding: 0.5rem;
   font-size: 1rem;
 }
+
+.page-container {
+  margin: 2rem auto;
+  padding: 1rem;
+  max-width: 900px;
+}

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -19,7 +19,7 @@ export default function Dashboard() {
   }, []);
 
   return (
-    <Container sx={{ mt: 2 }}>
+    <Container className="page-container">
       <Typography variant="h4" gutterBottom>Dashboard</Typography>
       <Grid container spacing={2}>
         {entities.map((e) => (

--- a/src/DoctorDashboard.js
+++ b/src/DoctorDashboard.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
+import { Container, Typography, Button } from '@mui/material';
+
 function DoctorDashboard({ onLogout }) {
   return (
-    <div>
-      <h2>Doctor Dashboard</h2>
-      <p>Welcome, doctor!</p>
-      <button onClick={onLogout}>Logout</button>
-    </div>
+    <Container className="page-container">
+      <Typography variant="h4" gutterBottom>Doctor Dashboard</Typography>
+      <Typography paragraph>Welcome, doctor!</Typography>
+      <Button variant="contained" onClick={onLogout}>Logout</Button>
+    </Container>
   );
 }
 

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Container, Typography, Box, Button, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 
 function Login({ onLogin }) {
   const [role, setRole] = useState('Student');
@@ -9,20 +10,20 @@ function Login({ onLogin }) {
   };
 
   return (
-    <div className="login-container">
-      <h2>Login</h2>
-      <form onSubmit={handleSubmit}>
-        <label>
-          Select Role:
-          <select value={role} onChange={(e) => setRole(e.target.value)}>
-            <option value="Student">Student</option>
-            <option value="Doctor">Doctor</option>
-            <option value="Manager">Manager</option>
-          </select>
-        </label>
-        <button type="submit">Login</button>
-      </form>
-    </div>
+    <Container className="page-container login-container">
+      <Typography variant="h4" gutterBottom>Login</Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 300 }}>
+        <FormControl fullWidth>
+          <InputLabel id="role-label">Select Role</InputLabel>
+          <Select labelId="role-label" value={role} label="Select Role" onChange={(e) => setRole(e.target.value)}>
+            <MenuItem value="Student">Student</MenuItem>
+            <MenuItem value="Doctor">Doctor</MenuItem>
+            <MenuItem value="Manager">Manager</MenuItem>
+          </Select>
+        </FormControl>
+        <Button type="submit" variant="contained">Login</Button>
+      </Box>
+    </Container>
   );
 }
 

--- a/src/Manage.js
+++ b/src/Manage.js
@@ -4,7 +4,7 @@ import EntityTable from './EntityTable';
 
 export default function Manage() {
   return (
-    <Container sx={{ mt: 2 }}>
+    <Container className="page-container">
       <Typography variant="h4" gutterBottom>Manage Data</Typography>
       <EntityTable entity="classes" fields={["name"]} />
       <EntityTable entity="courses" fields={["name"]} />

--- a/src/ManagerDashboard.js
+++ b/src/ManagerDashboard.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
+import { Container, Typography, Button } from '@mui/material';
+
 function ManagerDashboard({ onLogout }) {
   return (
-    <div>
-      <h2>Manager Dashboard</h2>
-      <p>Welcome, manager!</p>
-      <button onClick={onLogout}>Logout</button>
-    </div>
+    <Container className="page-container">
+      <Typography variant="h4" gutterBottom>Manager Dashboard</Typography>
+      <Typography paragraph>Welcome, manager!</Typography>
+      <Button variant="contained" onClick={onLogout}>Logout</Button>
+    </Container>
   );
 }
 

--- a/src/StudentDashboard.js
+++ b/src/StudentDashboard.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
+import { Container, Typography, Button } from '@mui/material';
+
 function StudentDashboard({ onLogout }) {
   return (
-    <div>
-      <h2>Student Dashboard</h2>
-      <p>Welcome, student!</p>
-      <button onClick={onLogout}>Logout</button>
-    </div>
+    <Container className="page-container">
+      <Typography variant="h4" gutterBottom>Student Dashboard</Typography>
+      <Typography paragraph>Welcome, student!</Typography>
+      <Button variant="contained" onClick={onLogout}>Logout</Button>
+    </Container>
   );
 }
 


### PR DESCRIPTION
## Summary
- ignore generated SQLite DB
- add reusable page container styling
- restyle login page and dashboards using Material UI components

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a792837248322892895364e0fe142